### PR TITLE
Bump pygments from 2.6.1 to 2.7.4 in /docs (#81)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,4 @@ markdown==3.2.2
 mkdocs-exclude==1.0.2
 mkdocs-material==5.5.0
 markdown-include==0.5.1
-pygments==2.6.1
+pygments==2.7.4

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,7 +4,7 @@ flake8==3.8.3
 isort==5.2.1
 pycodestyle==2.6.0
 pyflakes==2.2.0
-Pygments==2.6.1
+Pygments==2.7.4
 pydantic==1.6.1
 pytest==5.4.3
 pytest-cov==2.10.0


### PR DESCRIPTION
* Bump pygments from 2.6.1 to 2.7.4 in /docs

Bumps [pygments](https://github.com/pygments/pygments) from 2.6.1 to 2.7.4.
- [Release notes](https://github.com/pygments/pygments/releases)
- [Changelog](https://github.com/pygments/pygments/blob/master/CHANGES)
- [Commits](https://github.com/pygments/pygments/compare/2.6.1...2.7.4)

Signed-off-by: dependabot[bot] <support@github.com>

* update pygments in other file

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Samuel Colvin <s@muelcolvin.com>